### PR TITLE
Remove useless test

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,8 +1,6 @@
 var path = require('path');
 
-var outDirectory = (process.env.NODE_ENV === 'production') ?
-  'dist' :
-  'build';
+var outDirectory = 'dist';
 
 module.exports = {
   entry: [


### PR DESCRIPTION
The NODE_ENV is forced to `production`, so the build folder is never used.
cfr.: https://github.com/bananaoomarang/isomorphic-redux/blob/master/package.json#L10
